### PR TITLE
- remove permissions

### DIFF
--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -4,10 +4,6 @@
 <dict>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>Need location</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Need location</string>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>Need location</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
## Connection with issue(s)
Apple store submission rejection.

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->
We remove the iOS permission from the iOS project as we currently got a rejection from Apple because we use this keys within the plugin.
We remove because we do not want to add fake permissions in our application Info..plist file.

## Testing and Review Notes
No testing needed.

